### PR TITLE
Add option for an wakeup margin

### DIFF
--- a/S90.acpiwakeup
+++ b/S90.acpiwakeup
@@ -12,7 +12,7 @@ if [ "$(basename "$0")" != "testwakeup" ] ; then
     # Read arguments for acpi-wakeup from conf-file
     . /etc/vdr/vdr-addon-acpiwakeup.conf
     WAKEUP_FILE="/var/cache/vdr/acpiwakeup.time"
-    LOG="logger -t vdr-addon-acpiwakeup "
+    LOG="logger -t [vdr-addon-acpiwakeup] "
 else
     WAKEUP_FILE=$WAKEUP_FILE
     LOG="nop"
@@ -24,13 +24,16 @@ nop() {
 }
 
 # Defaults:
-[ -z "$ACPI_ENABLED" ]       && export ACPI_ENABLED="yes"
-[ -z "$ACPI_REGULAR_DAYS" ]  && export ACPI_REGULAR_DAYS="0"
-[ -z "$ACPI_REGULAR_TIME" ]  && export ACPI_REGULAR_TIME="00:00"
-[ -z "$ACPI_START_AHEAD" ]   && export ACPI_START_AHEAD="5"
-[ -z "$WAKEALARM" ]          && export WAKEALARM="/sys/class/rtc/rtc0/wakealarm"
+[ -z "$ACPI_ENABLED" ]          && export ACPI_ENABLED="yes"
+[ -z "$ACPI_MAX_MARGIN_HOURS" ] && export ACPI_MAX_MARGIN_HOURS="0"
+[ -z "$ACPI_REGULAR_DAYS" ]     && export ACPI_REGULAR_DAYS="0"
+[ -z "$ACPI_REGULAR_TIME" ]     && export ACPI_REGULAR_TIME="00:00"
+[ -z "$ACPI_START_AHEAD" ]      && export ACPI_START_AHEAD="5"
+[ -z "$WAKEALARM" ]             && export WAKEALARM="/sys/class/rtc/rtc0/wakealarm"
+NEXT_TIMER="(timer)"
 
 TIMER=$1
+NOW=$(date +%s)
 
 AcpiError() {
     $LOG "No writeable $WAKEALARM found. RTC needed!!!"
@@ -53,8 +56,8 @@ SetWakeupTime_RTC() {
     local -i ts="$1"
 
     if [ -w $WAKEALARM ] && ResetWakeupTime ; then
-            wakeup_offset="+$(( ts - $(date +%s) ))"
-            $LOG "Writing $wakeup_offset (for $ts) to $WAKEALARM"
+            wakeup_offset="+$(( ts - NOW ))"
+            $LOG "Writing $wakeup_offset $NEXT_TIMER to $WAKEALARM"
             # We use a relative time because of a bug with absolute
             # time and local vs. UTC timing, and avoid the handling of offsets
             echo "$wakeup_offset" > $WAKEALARM 2>/dev/null && return 0
@@ -81,7 +84,7 @@ SetWakeupTime() {
             [ "$1" -lt "$new_date" ] && continue
 	    $LOG "RTC did not accept $1, try setting ACPI alarm time to: $(date -d@"$new_date") ($new_date)"
             if SetWakeupTime_RTC "$new_date" ; then
-                # remember wakeup time for stop script
+                # Remember wakeup time for stop script
                 echo "$new_date" >"$WAKEUP_FILE"
                 return 0
             fi
@@ -101,10 +104,10 @@ IsRegularDayOfWeek() {
 }
 
 if [ $ACPI_ENABLED = "yes" ] ; then
-    # Check if we should wake up before the next timer:
+    # Check if we should wake up before the next timer
     if [ "$ACPI_REGULAR_DAYS" != "0" ] ; then
         REGULAR_TIMER=$(date -d "$ACPI_REGULAR_TIME" +%s)
-        if [ "$REGULAR_TIMER" -lt "$(date +%s)" ] ; then
+        if [ "$REGULAR_TIMER" -lt "$NOW" ] ; then
             REGULAR_TIMER=$(( REGULAR_TIMER + 24 * 60 * 60))
         fi
         while ! IsRegularDayOfWeek $REGULAR_TIMER ; do
@@ -113,10 +116,21 @@ if [ $ACPI_ENABLED = "yes" ] ; then
 
         if [ "$TIMER" -eq 0 ] || [ "$TIMER" -gt 0 -a "$REGULAR_TIMER" -lt "$TIMER" ] ; then
             TIMER=$REGULAR_TIMER
+            NEXT_TIMER="(regular day)"
         fi
     fi
+
+    # Check if we should wake up within the maximum margin hours
+    if [ "$ACPI_MAX_MARGIN_HOURS" -gt 0 ] ; then
+        MAX_MARGIN_TIMER=$((NOW + (60 * 60 * ACPI_MAX_MARGIN_HOURS)))
+        if [ "$TIMER" -eq 0 ] || [ "$TIMER" -gt 0 -a "$MAX_MARGIN_TIMER" -lt "$TIMER" ] ; then
+            TIMER=$MAX_MARGIN_TIMER
+            NEXT_TIMER="(margin)"
+        fi
+    fi
+
     if [ $TIMER -gt 0 ] ; then
-        MIN_START_AHEAD=$(($(date +%s) + (60 * ACPI_START_AHEAD) ))
+        MIN_START_AHEAD=$((NOW + (60 * ACPI_START_AHEAD) ))
         if [ $MIN_START_AHEAD -gt $TIMER ]; then
             $LOG "Can not set wakeup time less than $ACPI_START_AHEAD minutes ahead."
             echo "ABORT_MESSAGE=\"Wakeup in less than $ACPI_START_AHEAD minutes, aborting!\""

--- a/S90.acpiwakeup
+++ b/S90.acpiwakeup
@@ -8,35 +8,13 @@
 # ACPI.
 #
 
-if [ "$(basename "$0")" != 'testwakeup' ] ; then
-    # Read arguments for acpi-wakeup from conf-file
-    . /etc/vdr/vdr-addon-acpiwakeup.conf
-    WAKEUP_FILE='/var/cache/vdr/acpiwakeup.time'
-    LOG='logger -t [vdr-addon-acpiwakeup]'
-else
-    # This variable is assigned to itself, so the assignment does nothing.
-    # WAKEUP_FILE=$WAKEUP_FILE
-    LOG='nop'
-fi
-
-nop() {  # No Operation
-    echo -n ""
+### Functions ###
+LOG() {
+    [ -z "$TESTWAKEUP" ] && logger -t '[vdr-addon-acpiwakeup]' "$@"
 }
 
-# Defaults:
-[ -z "$ACPI_ENABLED" ]          && export ACPI_ENABLED='yes'
-[ -z "$ACPI_MAX_MARGIN_HOURS" ] && export ACPI_MAX_MARGIN_HOURS=0
-[ -z "$ACPI_REGULAR_DAYS" ]     && export ACPI_REGULAR_DAYS=0
-[ -z "$ACPI_REGULAR_TIME" ]     && export ACPI_REGULAR_TIME='00:00'
-[ -z "$ACPI_START_AHEAD" ]      && export ACPI_START_AHEAD=5
-[ -z "$WAKEALARM" ]             && export WAKEALARM='/sys/class/rtc/rtc0/wakealarm'
-NEXT_TIMER='(timer)'
-
-TIMER="$1"  # Next timer in seconds since 1970-01-01 00:00:00 UTC, or 0 if no timer
-NOW=$(date +%s)  # Current time in seconds since 1970-01-01 00:00:00 UTC
-
 AcpiError() {
-    $LOG "ERROR: No writeable $WAKEALARM found. RTC needed!"
+    LOG "ERROR: No writeable $WAKEALARM found. RTC needed!"
     echo "ABORT_MESSAGE=\"RTC not writable, shutdown aborted!\""
     exit 1
 }
@@ -44,10 +22,10 @@ AcpiError() {
 
 ResetWakeupTime_RTC() {
     if [ -w "$WAKEALARM" ] ; then
-        $LOG "Writing 0 to $WAKEALARM"
+        LOG "Writing 0 to $WAKEALARM"
         echo 0 > "$WAKEALARM" && return 0
     else
-        $LOG "ERROR: WAKEALARM $WAKEALARM not writable"
+        LOG "ERROR: WAKEALARM $WAKEALARM not writable"
     fi
     return 1
 }
@@ -56,7 +34,7 @@ SetWakeupTime_RTC() {
     local -i ts="$1"
     if [ -w "$WAKEALARM" ] && ResetWakeupTime ; then
             wakeup_offset="+$((ts - NOW))"
-            $LOG "Writing $wakeup_offset $NEXT_TIMER to $WAKEALARM"
+            LOG "Writing $wakeup_offset $NEXT_TIMER to $WAKEALARM"
             # We use a relative time because of a bug with absolute
             # time and local vs. UTC timing, and avoid the handling of offsets
             echo "$wakeup_offset" > "$WAKEALARM" 2>/dev/null && return 0
@@ -65,12 +43,12 @@ SetWakeupTime_RTC() {
 }
 
 ResetWakeupTime() {
-    $LOG 'Resetting ACPI alarm time'
+    LOG 'Resetting ACPI alarm time'
     ResetWakeupTime_RTC || AcpiError
 }
 
 SetWakeupTime() {
-    $LOG "Try setting ACPI alarm time to: $(date -d@"$1") ($1)"
+    LOG "Try setting ACPI alarm time to: $(date -d@"$1") ($1)"
     if SetWakeupTime_RTC "$1" ; then
         echo "$1" > "$WAKEUP_FILE"
     else
@@ -81,7 +59,7 @@ SetWakeupTime() {
         for d in "${dates[@]}" ; do
 	        new_date=$(date -d "$d" +%s)
             [ "$1" -lt "$new_date" ] && continue
-	        $LOG "RTC did not accept $1, try setting ACPI alarm time to: $(date -d@"$new_date") ($new_date)"
+	        LOG "RTC did not accept $1, try setting ACPI alarm time to: $(date -d@"$new_date") ($new_date)"
             if SetWakeupTime_RTC "$new_date" ; then
                 # Remember wakeup time for stop script
                 echo "$new_date" >"$WAKEUP_FILE"
@@ -100,6 +78,30 @@ IsRegularDayOfWeek() {
     return 1
 }
 
+### Main ###
+if [ "$(basename "$0")" != 'testwakeup' ] ; then
+    # Read arguments for acpi-wakeup from conf-file
+    . /etc/vdr/vdr-addon-acpiwakeup.conf
+    WAKEUP_FILE='/var/cache/vdr/acpiwakeup.time'
+else
+    # This variable is assigned to itself, so the assignment does nothing.
+    # WAKEUP_FILE=$WAKEUP_FILE
+    TESTWAKEUP='true'
+fi
+
+# Defaults for variables:
+[ -z "$ACPI_ENABLED" ]          && export ACPI_ENABLED='yes'
+[ -z "$ACPI_MAX_MARGIN_HOURS" ] && export ACPI_MAX_MARGIN_HOURS=0
+[ -z "$ACPI_REGULAR_DAYS" ]     && export ACPI_REGULAR_DAYS=0
+[ -z "$ACPI_REGULAR_TIME" ]     && export ACPI_REGULAR_TIME='00:00'
+[ -z "$ACPI_START_AHEAD" ]      && export ACPI_START_AHEAD=5
+[ -z "$WAKEALARM" ]             && export WAKEALARM='/sys/class/rtc/rtc0/wakealarm'
+NEXT_TIMER='(timer)'  # Type of the next timer
+
+TIMER="$1"  # Next timer in seconds since 1970-01-01 00:00:00 UTC, or 0 if no timer
+NOW=$(date +%s)  # Current time in seconds since 1970-01-01 00:00:00 UTC
+
+
 if [ "$ACPI_ENABLED" = 'yes' ] ; then
     # Check if we should wake up before the next timer
     if [ "$ACPI_REGULAR_DAYS" != '0' ] ; then
@@ -114,7 +116,7 @@ if [ "$ACPI_ENABLED" = 'yes' ] ; then
         # if [ "$TIMER" -eq 0 ] || [ "$TIMER" -gt 0 -a "$REGULAR_TIMER" -lt "$TIMER" ] ; then
         # This is equivalent to the original condition, but it eliminates the need for the -gt 0 check,
         # since the -lt check will only be true if $TIMER is greater than 0
-        if [ "$TIMER" -eq 0 ] || [ "$REGULAR_TIMER" -lt "$TIMER" ]; then
+        if [ "$TIMER" -eq 0 ] || [ "$REGULAR_TIMER" -lt "$TIMER" ] ; then
             TIMER="$REGULAR_TIMER"
             NEXT_TIMER='(regular day)'
         fi
@@ -132,7 +134,7 @@ if [ "$ACPI_ENABLED" = 'yes' ] ; then
     if [ "$TIMER" -gt 0 ] ; then
         MIN_START_AHEAD=$((NOW + (60 * ACPI_START_AHEAD)))
         if [ "$MIN_START_AHEAD" -gt "$TIMER" ] ; then
-            $LOG "Can not set wakeup time less than $ACPI_START_AHEAD minutes ahead."
+            LOG "Can not set wakeup time less than $ACPI_START_AHEAD minutes ahead."
             echo "ABORT_MESSAGE=\"Wakeup in less than $ACPI_START_AHEAD minutes, aborting!\""
             exit 1
         fi
@@ -148,5 +150,5 @@ if [ "$ACPI_ENABLED" = 'yes' ] ; then
     fi
 
 else
-    $LOG 'ACPIWakeup functionality is disabled'
+    LOG 'ACPIWakeup functionality is disabled'
 fi

--- a/S90.acpiwakeup
+++ b/S90.acpiwakeup
@@ -9,18 +9,16 @@
 #
 
 if [ "$(basename "$0")" != "testwakeup" ] ; then
-    # read arguments for acpi-wakeup from conf-file
+    # Read arguments for acpi-wakeup from conf-file
     . /etc/vdr/vdr-addon-acpiwakeup.conf
     WAKEUP_FILE="/var/cache/vdr/acpiwakeup.time"
-
     LOG="logger -t vdr-addon-acpiwakeup "
 else
     WAKEUP_FILE=$WAKEUP_FILE
     LOG="nop"
 fi
 
-nop()
-{
+nop() {
     # No Operation
     echo -n ""
 }
@@ -34,20 +32,17 @@ nop()
 
 TIMER=$1
 
-AcpiError()
-{
+AcpiError() {
     $LOG "No writeable $WAKEALARM found. RTC needed!!!"
     echo "ABORT_MESSAGE=\"RTC not writable, shutdown aborted!\""
     exit 1
 }
 
 
-ResetWakeupTime_RTC()
-{
-    if [ -w $WAKEALARM ]; then
+ResetWakeupTime_RTC() {
+    if [ -w $WAKEALARM ] ; then
         $LOG "Writing 0 to $WAKEALARM"
-        echo 0 > $WAKEALARM &&
-        return 0
+        echo 0 > $WAKEALARM && return 0
     else
         $LOG "WAKEALARM $WAKEALARM not writable"
     fi
@@ -57,41 +52,35 @@ ResetWakeupTime_RTC()
 SetWakeupTime_RTC() {
     local -i ts="$1"
 
-    if [ -w $WAKEALARM ] && ResetWakeupTime; then
+    if [ -w $WAKEALARM ] && ResetWakeupTime ; then
             wakeup_offset="+$(( ts - $(date +%s) ))"
             $LOG "Writing $wakeup_offset (for $ts) to $WAKEALARM"
-            # we use a relative time because of a bug with absolute
+            # We use a relative time because of a bug with absolute
             # time and local vs. UTC timing, and avoid the handling of offsets
             echo "$wakeup_offset" > $WAKEALARM 2>/dev/null && return 0
     fi
     return 1
 }
 
-ResetWakeupTime()
-{
+ResetWakeupTime() {
     $LOG "Resetting ACPI alarm time"
-    ResetWakeupTime_RTC || \
-    AcpiError
+    ResetWakeupTime_RTC || AcpiError
 }
 
-SetWakeupTime()
-{
+SetWakeupTime() {
     $LOG "Try setting ACPI alarm time to: $(date -d@"$1") ($1)"
-    if SetWakeupTime_RTC "$1"
-    then
+    if SetWakeupTime_RTC "$1" ; then
         echo "$1" >"$WAKEUP_FILE"
     else
         # If the RTC did not accept the date, it might be to far in the future
         # see https://github.com/torvalds/linux/commit/6a6af3d04435adfdaab363624ec569a9b5d3973c
         # so we need to try waking up in less than a year, less than a month or less than a day
         dates=("now +1 year -1 min" "now +1 month -1 min" "now +1 week -1 min" "now +1 day -1 min")
-        for d in "${dates[@]}"
-        do
+        for d in "${dates[@]}" ; do
 	    new_date=$(date -d "$d" +%s)
             [ "$1" -lt "$new_date" ] && continue
 	    $LOG "RTC did not accept $1, try setting ACPI alarm time to: $(date -d@"$new_date") ($new_date)"
-            if SetWakeupTime_RTC "$new_date"
-            then
+            if SetWakeupTime_RTC "$new_date" ; then
                 # remember wakeup time for stop script
                 echo "$new_date" >"$WAKEUP_FILE"
                 return 0
@@ -101,22 +90,19 @@ SetWakeupTime()
     fi
 }
 
-IsRegularDayOfWeek()
-{
+IsRegularDayOfWeek() {
     local day
-    for day in $ACPI_REGULAR_DAYS
-    do
-        if [ "$day" = "$(date -d "@$1" +%u)" ]
-        then
+    for day in $ACPI_REGULAR_DAYS ; do
+        if [ "$day" = "$(date -d "@$1" +%u)" ] ; then
             return 0
         fi
     done
     return 1
 }
 
-if [ $ACPI_ENABLED = "yes" ]; then
-    # check if we should wake up before the next timer:
-    if [ "$ACPI_REGULAR_DAYS" != "0" ]; then
+if [ $ACPI_ENABLED = "yes" ] ; then
+    # Check if we should wake up before the next timer:
+    if [ "$ACPI_REGULAR_DAYS" != "0" ] ; then
         REGULAR_TIMER=$(date -d "$ACPI_REGULAR_TIME" +%s)
         if [ "$REGULAR_TIMER" -lt "$(date +%s)" ] ; then
             REGULAR_TIMER=$(( REGULAR_TIMER + 24 * 60 * 60))
@@ -129,7 +115,7 @@ if [ $ACPI_ENABLED = "yes" ]; then
             TIMER=$REGULAR_TIMER
         fi
     fi
-    if [ $TIMER -gt 0 ]; then
+    if [ $TIMER -gt 0 ] ; then
         MIN_START_AHEAD=$(($(date +%s) + (60 * ACPI_START_AHEAD) ))
         if [ $MIN_START_AHEAD -gt $TIMER ]; then
             $LOG "Can not set wakeup time less than $ACPI_START_AHEAD minutes ahead."
@@ -137,11 +123,11 @@ if [ $ACPI_ENABLED = "yes" ]; then
             exit 1
         fi
 
-        # adjust wakeup time by ACPI_START_AHEAD
-    TIMER=$(( TIMER - (60 * ACPI_START_AHEAD) ))
+        # Adjust wakeup time by ACPI_START_AHEAD
+        TIMER=$(( TIMER - (60 * ACPI_START_AHEAD) ))
     fi
 
-    if [ $TIMER -eq 0 ]; then
+    if [ $TIMER -eq 0 ] ; then
         ResetWakeupTime
     else
         SetWakeupTime "$TIMER"

--- a/S90.acpiwakeup
+++ b/S90.acpiwakeup
@@ -10,7 +10,11 @@
 
 ### Functions ###
 LOG() {
-    [ -z "$TESTWAKEUP" ] && logger -t '[vdr-addon-acpiwakeup]' "$@"
+    if [ -z "$TESTWAKEUP" ] ; then 
+        logger -t '[vdr-addon-acpiwakeup]' "$*"
+    else
+        [ -t 1 ] && echo "[vdr-addon-acpiwakeup] $*"
+    fi
 }
 
 AcpiError() {

--- a/S90.acpiwakeup
+++ b/S90.acpiwakeup
@@ -8,145 +8,145 @@
 # ACPI.
 #
 
-if [ "$(basename "$0")" != "testwakeup" ] ; then
+if [ "$(basename "$0")" != 'testwakeup' ] ; then
     # Read arguments for acpi-wakeup from conf-file
     . /etc/vdr/vdr-addon-acpiwakeup.conf
-    WAKEUP_FILE="/var/cache/vdr/acpiwakeup.time"
-    LOG="logger -t [vdr-addon-acpiwakeup] "
+    WAKEUP_FILE='/var/cache/vdr/acpiwakeup.time'
+    LOG='logger -t [vdr-addon-acpiwakeup]'
 else
-    WAKEUP_FILE=$WAKEUP_FILE
-    LOG="nop"
+    # This variable is assigned to itself, so the assignment does nothing.
+    # WAKEUP_FILE=$WAKEUP_FILE
+    LOG='nop'
 fi
 
-nop() {
-    # No Operation
+nop() {  # No Operation
     echo -n ""
 }
 
 # Defaults:
-[ -z "$ACPI_ENABLED" ]          && export ACPI_ENABLED="yes"
-[ -z "$ACPI_MAX_MARGIN_HOURS" ] && export ACPI_MAX_MARGIN_HOURS="0"
-[ -z "$ACPI_REGULAR_DAYS" ]     && export ACPI_REGULAR_DAYS="0"
-[ -z "$ACPI_REGULAR_TIME" ]     && export ACPI_REGULAR_TIME="00:00"
-[ -z "$ACPI_START_AHEAD" ]      && export ACPI_START_AHEAD="5"
-[ -z "$WAKEALARM" ]             && export WAKEALARM="/sys/class/rtc/rtc0/wakealarm"
-NEXT_TIMER="(timer)"
+[ -z "$ACPI_ENABLED" ]          && export ACPI_ENABLED='yes'
+[ -z "$ACPI_MAX_MARGIN_HOURS" ] && export ACPI_MAX_MARGIN_HOURS=0
+[ -z "$ACPI_REGULAR_DAYS" ]     && export ACPI_REGULAR_DAYS=0
+[ -z "$ACPI_REGULAR_TIME" ]     && export ACPI_REGULAR_TIME='00:00'
+[ -z "$ACPI_START_AHEAD" ]      && export ACPI_START_AHEAD=5
+[ -z "$WAKEALARM" ]             && export WAKEALARM='/sys/class/rtc/rtc0/wakealarm'
+NEXT_TIMER='(timer)'
 
-TIMER=$1
-NOW=$(date +%s)
+TIMER="$1"  # Next timer in seconds since 1970-01-01 00:00:00 UTC, or 0 if no timer
+NOW=$(date +%s)  # Current time in seconds since 1970-01-01 00:00:00 UTC
 
 AcpiError() {
-    $LOG "No writeable $WAKEALARM found. RTC needed!!!"
+    $LOG "ERROR: No writeable $WAKEALARM found. RTC needed!"
     echo "ABORT_MESSAGE=\"RTC not writable, shutdown aborted!\""
     exit 1
 }
 
 
 ResetWakeupTime_RTC() {
-    if [ -w $WAKEALARM ] ; then
+    if [ -w "$WAKEALARM" ] ; then
         $LOG "Writing 0 to $WAKEALARM"
-        echo 0 > $WAKEALARM && return 0
+        echo 0 > "$WAKEALARM" && return 0
     else
-        $LOG "WAKEALARM $WAKEALARM not writable"
+        $LOG "ERROR: WAKEALARM $WAKEALARM not writable"
     fi
     return 1
 }
 
 SetWakeupTime_RTC() {
     local -i ts="$1"
-
-    if [ -w $WAKEALARM ] && ResetWakeupTime ; then
-            wakeup_offset="+$(( ts - NOW ))"
+    if [ -w "$WAKEALARM" ] && ResetWakeupTime ; then
+            wakeup_offset="+$((ts - NOW))"
             $LOG "Writing $wakeup_offset $NEXT_TIMER to $WAKEALARM"
             # We use a relative time because of a bug with absolute
             # time and local vs. UTC timing, and avoid the handling of offsets
-            echo "$wakeup_offset" > $WAKEALARM 2>/dev/null && return 0
+            echo "$wakeup_offset" > "$WAKEALARM" 2>/dev/null && return 0
     fi
     return 1
 }
 
 ResetWakeupTime() {
-    $LOG "Resetting ACPI alarm time"
+    $LOG 'Resetting ACPI alarm time'
     ResetWakeupTime_RTC || AcpiError
 }
 
 SetWakeupTime() {
     $LOG "Try setting ACPI alarm time to: $(date -d@"$1") ($1)"
     if SetWakeupTime_RTC "$1" ; then
-        echo "$1" >"$WAKEUP_FILE"
+        echo "$1" > "$WAKEUP_FILE"
     else
-        # If the RTC did not accept the date, it might be to far in the future
-        # see https://github.com/torvalds/linux/commit/6a6af3d04435adfdaab363624ec569a9b5d3973c
-        # so we need to try waking up in less than a year, less than a month or less than a day
+        # If the RTC did not accept the date, it might be to far in the future.
+        # See https://github.com/torvalds/linux/commit/6a6af3d04435adfdaab363624ec569a9b5d3973c
+        # So we need to try waking up in less than a year, less than a month or less than a day
         dates=("now +1 year -1 min" "now +1 month -1 min" "now +1 week -1 min" "now +1 day -1 min")
         for d in "${dates[@]}" ; do
-	    new_date=$(date -d "$d" +%s)
+	        new_date=$(date -d "$d" +%s)
             [ "$1" -lt "$new_date" ] && continue
-	    $LOG "RTC did not accept $1, try setting ACPI alarm time to: $(date -d@"$new_date") ($new_date)"
+	        $LOG "RTC did not accept $1, try setting ACPI alarm time to: $(date -d@"$new_date") ($new_date)"
             if SetWakeupTime_RTC "$new_date" ; then
                 # Remember wakeup time for stop script
                 echo "$new_date" >"$WAKEUP_FILE"
                 return 0
             fi
         done
-	AcpiError
+	    AcpiError
     fi
 }
 
 IsRegularDayOfWeek() {
     local day
     for day in $ACPI_REGULAR_DAYS ; do
-        if [ "$day" = "$(date -d "@$1" +%u)" ] ; then
-            return 0
-        fi
+        [ "$day" = "$(date -d "@$1" +%u)" ] && return 0
     done
     return 1
 }
 
-if [ $ACPI_ENABLED = "yes" ] ; then
+if [ "$ACPI_ENABLED" = 'yes' ] ; then
     # Check if we should wake up before the next timer
-    if [ "$ACPI_REGULAR_DAYS" != "0" ] ; then
+    if [ "$ACPI_REGULAR_DAYS" != '0' ] ; then
         REGULAR_TIMER=$(date -d "$ACPI_REGULAR_TIME" +%s)
         if [ "$REGULAR_TIMER" -lt "$NOW" ] ; then
-            REGULAR_TIMER=$(( REGULAR_TIMER + 24 * 60 * 60))
+            REGULAR_TIMER=$((REGULAR_TIMER + (24 * 60 * 60)))
         fi
-        while ! IsRegularDayOfWeek $REGULAR_TIMER ; do
-            REGULAR_TIMER=$(( REGULAR_TIMER + 24 * 60 * 60))
+        while ! IsRegularDayOfWeek "$REGULAR_TIMER" ; do
+            REGULAR_TIMER=$((REGULAR_TIMER + (24 * 60 * 60)))
         done
 
-        if [ "$TIMER" -eq 0 ] || [ "$TIMER" -gt 0 -a "$REGULAR_TIMER" -lt "$TIMER" ] ; then
-            TIMER=$REGULAR_TIMER
-            NEXT_TIMER="(regular day)"
+        # if [ "$TIMER" -eq 0 ] || [ "$TIMER" -gt 0 -a "$REGULAR_TIMER" -lt "$TIMER" ] ; then
+        # This is equivalent to the original condition, but it eliminates the need for the -gt 0 check,
+        # since the -lt check will only be true if $TIMER is greater than 0
+        if [ "$TIMER" -eq 0 ] || [ "$REGULAR_TIMER" -lt "$TIMER" ]; then
+            TIMER="$REGULAR_TIMER"
+            NEXT_TIMER='(regular day)'
         fi
     fi
 
     # Check if we should wake up within the maximum margin hours
     if [ "$ACPI_MAX_MARGIN_HOURS" -gt 0 ] ; then
         MAX_MARGIN_TIMER=$((NOW + (60 * 60 * ACPI_MAX_MARGIN_HOURS)))
-        if [ "$TIMER" -eq 0 ] || [ "$TIMER" -gt 0 -a "$MAX_MARGIN_TIMER" -lt "$TIMER" ] ; then
-            TIMER=$MAX_MARGIN_TIMER
-            NEXT_TIMER="(margin)"
+        if [ "$TIMER" -eq 0 ] || [ "$MAX_MARGIN_TIMER" -lt "$TIMER" ] ; then
+            TIMER="$MAX_MARGIN_TIMER"
+            NEXT_TIMER='(margin)'
         fi
     fi
 
-    if [ $TIMER -gt 0 ] ; then
-        MIN_START_AHEAD=$((NOW + (60 * ACPI_START_AHEAD) ))
-        if [ $MIN_START_AHEAD -gt $TIMER ]; then
+    if [ "$TIMER" -gt 0 ] ; then
+        MIN_START_AHEAD=$((NOW + (60 * ACPI_START_AHEAD)))
+        if [ "$MIN_START_AHEAD" -gt "$TIMER" ] ; then
             $LOG "Can not set wakeup time less than $ACPI_START_AHEAD minutes ahead."
             echo "ABORT_MESSAGE=\"Wakeup in less than $ACPI_START_AHEAD minutes, aborting!\""
             exit 1
         fi
 
         # Adjust wakeup time by ACPI_START_AHEAD
-        TIMER=$(( TIMER - (60 * ACPI_START_AHEAD) ))
+        TIMER=$((TIMER - (60 * ACPI_START_AHEAD)))
     fi
 
-    if [ $TIMER -eq 0 ] ; then
+    if [ "$TIMER" -eq 0 ] ; then
         ResetWakeupTime
     else
         SetWakeupTime "$TIMER"
     fi
 
 else
-    $LOG "ACPIWakeup functionality is disabled"
+    $LOG 'ACPIWakeup functionality is disabled'
 fi

--- a/vdr-addon-acpiwakeup.conf
+++ b/vdr-addon-acpiwakeup.conf
@@ -15,4 +15,4 @@ ACPI_REGULAR_TIME=01:00  # HH:MM
 
 # Wakeup maximum margin in hours. Ensure that the machine is woken up at least
 # in this hours if next wakeup time is not within the margin.
-ACPI_MAX_MARGIN_HOURS=36
+#ACPI_MAX_MARGIN_HOURS=36

--- a/vdr-addon-acpiwakeup.conf
+++ b/vdr-addon-acpiwakeup.conf
@@ -6,9 +6,13 @@ ACPI_START_AHEAD=5
 
 # If you want your VDR machine to wakeup in regular intervals (i.e. for
 # updating EPG data), specify the days of the week and the wakeup time.
-# 
+#
 # Days of the week for regular wakeup (not set=Disabled, 1=Monday...7=Sunday)
 # ACPI_REGULAR_DAYS="1 2 3 4 5 6 7"
 
 # Wakeup time
 ACPI_REGULAR_TIME=01:00  # HH:MM
+
+# Wakeup maximum margin in hours. Ensure that the machine is woken up at least
+# in this hours if next wakeup time is not within the margin.
+ACPI_MAX_MARGIN_HOURS=36


### PR DESCRIPTION
Instead of fixed wakeup days with an fixed wakeup hour this pull request adds an option to set an wakeup margin.
Can be used together with wakeup days. For example: wake up on sunday at 8 am for backup and additional at least after 36 hours wakeup margin to keep epg up to date.

The script now also indicates what type of wakeup is used (timer, regular day, margin)